### PR TITLE
Explicitly set exit code on success.

### DIFF
--- a/bin/pipelign
+++ b/bin/pipelign
@@ -208,8 +208,8 @@ if __name__=="__main__":
             if os.path.exists(zName):
                 os.chmod(zName,0o777)
         '''
-        msg = '\nThank you for using Pipelign\n'
-        sys.exit(msg)
+        print('\nThank you for using Pipelign.\n')
+        sys.exit(0)
 
 
     #***************
@@ -251,7 +251,8 @@ if __name__=="__main__":
                 os.chmod(zName,0o777)
         '''
 
-        sys.exit('\nThank you for using Pipelign.\n')
+        print('\nThank you for using Pipelign.\n')
+        sys.exit(0)
 
     #***************
     # Assigns clusters to fragments based on BLAST and HMM search
@@ -269,9 +270,8 @@ if __name__=="__main__":
 
             msg += '\tCluster files for fragments are written in <frag.xx.fas>\n'
 
-        msg = '\nThank you for using Pipelign\n'
-
-        sys.exit(msg)
+        print('\nThank you for using Pipelign.\n')
+        sys.exit(0)
 
 
     #***************
@@ -303,8 +303,8 @@ if __name__=="__main__":
                 oh.write(msg)
 
 
-        msg = '\nThank you for using Pipelign\n'
-        sys.exit(msg)
+        print('\nThank you for using Pipelign.\n')
+        sys.exit(0)
 
 
     #************
@@ -430,7 +430,9 @@ if __name__=="__main__":
             msg += ' Pipelign could not write the file <%s>\n' % mArgs.outFile
             msg += '\tSomething went wrong. Please check the output directory.\n'
             print(msg)
+            sys.exit(1)
             #cZip(cDir,tFileName,zName)
 
 
-        sys.exit('\nThank you for using Pipelign.\n')
+        print('\nThank you for using Pipelign.\n')
+        sys.exit(0)

--- a/pipelign/__init__.py
+++ b/pipelign/__init__.py
@@ -981,7 +981,8 @@ def longSeqClusters(tempDirPath,cDir,tDirName,tFileName):
     msg += '\tHMM database written in <pipelign.hmm>\n'
     print(msg)
 
-    sys.exit('\nThank you for using Pipelign.\n')
+    print('\nThank you for using Pipelign.\n')
+    sys.exit(0)
 
 #***********************************************************************
 
@@ -1367,7 +1368,8 @@ def longSeqAlignmentConsensus(numClusters,mArgs):
         print(msg)
 
     '''
-    #sys.exit('\nThank you for using Pipelign.\n')
+    # print('\nThank you for using Pipelign.\n')
+    # sys.exit(0)
 
 #***********************************************************************
 def longSeqAlignmentParallel(numClusters,mArgs):


### PR DESCRIPTION
Apparently `sys.exit(text)` sets the exit code to 1, which makes Galaxy mistakenly assume that the task failed. This change makes the tool exit with code 0 unless an error occurred.